### PR TITLE
avoid JSON.parse exception

### DIFF
--- a/lib/clients/public.js
+++ b/lib/clients/public.js
@@ -55,7 +55,6 @@ PublicClient.prototype = new function() {
     _.assign(opts, {
       'method': method.toUpperCase(),
       'uri': self.makeAbsoluteURI(self.makeRelativeURI(uriParts)),
-      'json': true,
     });
     self.addHeaders(opts);
     request(opts, self.makeRequestCallback(callback));


### PR DESCRIPTION
This patch removes `json: true` from the request in the PublicClient because otherwise `makeRequestCallback()` fails when it calls `JSON.parse` on the json result.  the callback was swallowing the exception and always returning null.

It may be more desireable to modify `makeRequestCallback` instead of removing `json: true`.
