### PR TITLE
Add ability to track orders

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,8 +265,14 @@ The orderbook has the following methods:
 `OrderbookSync` creates a local mirror of the orderbook on Coinbase Exchange using
 `Orderbook` and `WebsocketClient` as described [here](https://docs.exchange.coinbase.com/#real-time-order-book).
 
+Additionally, orders can be tracked through the `trackOrder(orderId)` method. An instance of the [EventEmitter]
+(https://nodejs.org/api/events.html#events_class_events_eventemitter) class will be returned. The type of order types
+(i.e. open, done, match, change) represent events that are emitted. The full websocket message is passed to the event
+callback function.
+
 ```javascript
 var CoinbaseExchange = require('coinbase-exchange');
 var orderbookSync = new CoinbaseExchange.OrderbookSync();
 console.log(orderbookSync.book.state());
+orderbookSync.trackOrder(orderId).once('done', function(data) { console.log(data); });
 ```

--- a/lib/orderbook_sync.js
+++ b/lib/orderbook_sync.js
@@ -1,3 +1,4 @@
+var EventEmitter = require('events').EventEmitter;
 var WebsocketClient = require('./clients/websocket.js');
 var PublicClient = require('./clients/public.js');
 var Orderbook = require('./orderbook.js');
@@ -12,6 +13,7 @@ var OrderbookSync = function(productID) {
   var self = this;
 
   self.productID = productID || 'BTC-USD';
+  self.trackedOrders = {};
 
   self._queue = [];
   self._sequence = -1;
@@ -108,6 +110,17 @@ _.assign(OrderbookSync.prototype, new function() {
         self.book.change(data);
         break;
     }
+
+    if (data.order_id in self.trackedOrders) {
+      // Emit message for tracked orders
+      self.trackedOrders[data.order_id].emit(data.type, data);
+    }
+  };
+
+  prototype.trackOrder = function(orderId) {
+    var self = this;
+    self.trackedOrders[orderId] = new EventEmitter();
+    return self.trackedOrders[orderId];
   };
 
 });


### PR DESCRIPTION
In the synced Orderbook, a `trackOrder(orderId)` method was added to monitor the lifecycle of an order. The method returns an [EventEmitter](https://nodejs.org/api/events.html#events_class_events_eventemitter) class which can listen to the events that are emitted by Orderbook.

``` javascript
var CoinbaseExchange = require('coinbase-exchange');
var orderbookSync = new CoinbaseExchange.OrderbookSync();
orderbookSync.trackOrder(orderId).once('done', function(data) { console.log(data); });
```
