### PR TITLE
Fix OrderbookSync init when using productId != BTC-USD

### DIFF
--- a/lib/orderbook.js
+++ b/lib/orderbook.js
@@ -73,6 +73,43 @@ _.assign(Orderbook.prototype, new function() {
     }
   };
 
+  prototype.getDepth = function(maxdepth) {
+    var self = this;
+    maxdepth = maxdepth || 0;
+    book = {
+      asks: [],
+      bids: []
+    };
+
+    var curdepth = 0;
+    var it = self._bids.iterator();
+    var bid;
+    while((bid = it.prev()) !== null) {
+      if (maxdepth && curdepth >= maxdepth)
+        break;
+      size = bid.orders.reduce(function(s,o) {
+          return s.add(o.size);
+      }, num(0));
+      book.bids.push([bid.price.toString(), size.toString()]);
+      curdepth++;
+    }
+
+    curdepth = 0;
+    var it = self._asks.iterator();
+    var ask;
+    while((ask = it.next()) !== null) {
+      if (maxdepth && curdepth >= maxdepth)
+        break;
+      size = ask.orders.reduce(function(s,o) {
+          return s.add(o.size);
+      }, num(0));
+      book.asks.push([ask.price.toString(), size.toString()]);
+      curdepth++;
+    }
+
+    return book;
+  };
+
   prototype.get = function(orderId) {
     return this._ordersByID[orderId]
   };

--- a/lib/orderbook.js
+++ b/lib/orderbook.js
@@ -1,5 +1,4 @@
 var RBTree = require('bintrees').RBTree;
-var num = require('num');
 var assert = require('assert');
 var _ = {assign: require('lodash.assign')}
 
@@ -10,11 +9,11 @@ var Orderbook = function() {
   self._ordersByID = {};
 
   self._bids = new RBTree(function(a, b) {
-    return a.price.cmp(b.price);
+    return a.price - b.price;
   });
 
   self._asks = new RBTree(function(a, b) {
-    return a.price.cmp(b.price);
+    return a.price - b.price;
   });
 };
 
@@ -34,8 +33,8 @@ _.assign(Orderbook.prototype, new function() {
         order = {
           id: order[2],
           side: 'buy',
-          price: num(order[0]),
-          size: num(order[1])
+          price: parseFloat(order[0]),
+          size: parseFloat(order[1])
         }
         self.add(order);
       });
@@ -44,8 +43,8 @@ _.assign(Orderbook.prototype, new function() {
         order = {
           id: order[2],
           side: 'sell',
-          price: num(order[0]),
-          size: num(order[1])
+          price: parseFloat(order[0]),
+          size: parseFloat(order[1])
         }
         self.add(order);
       });
@@ -88,9 +87,9 @@ _.assign(Orderbook.prototype, new function() {
       if (maxdepth && curdepth >= maxdepth)
         break;
       size = bid.orders.reduce(function(s,o) {
-          return s.add(o.size);
-      }, num(0));
-      book.bids.push([bid.price.toString(), size.toString()]);
+          return s + o.size;
+      }, 0);
+      book.bids.push([bid.price, size]);
       curdepth++;
     }
 
@@ -101,9 +100,9 @@ _.assign(Orderbook.prototype, new function() {
       if (maxdepth && curdepth >= maxdepth)
         break;
       size = ask.orders.reduce(function(s,o) {
-          return s.add(o.size);
-      }, num(0));
-      book.asks.push([ask.price.toString(), size.toString()]);
+          return s + o.size;
+      }, 0);
+      book.asks.push([ask.price, size]);
       curdepth++;
     }
 
@@ -120,8 +119,8 @@ _.assign(Orderbook.prototype, new function() {
     order = {
       id: order.order_id || order.id,
       side: order.side,
-      price: num(order.price),
-      size: num(order.size || order.remaining_size),
+      price: parseFloat(order.price),
+      size: parseFloat(order.size || order.remaining_size),
     };
 
     var tree = self._getTree(order.side);
@@ -164,8 +163,8 @@ _.assign(Orderbook.prototype, new function() {
   prototype.match = function(match) {
     var self = this;
 
-    var size = num(match.size);
-    var price = num(match.price);
+    var size = parseFloat(match.size);
+    var price = parseFloat(match.price);
     var tree = self._getTree(match.side);
     var node = tree.find({price: price});
     assert(node);
@@ -173,12 +172,12 @@ _.assign(Orderbook.prototype, new function() {
     var order = node.orders[0];
     assert.equal(order.id, match.maker_order_id);
 
-    order.size = order.size.sub(size);
+    order.size = order.size - size;
     self._ordersByID[order.id] = order;
 
     assert(order.size >= 0);
 
-    if (order.size.eq(0)) {
+    if (order.size == 0) {
       self.remove(order.id);
     }
   };
@@ -186,8 +185,8 @@ _.assign(Orderbook.prototype, new function() {
   prototype.change = function(change) {
     var self = this;
 
-    var size = num(change.new_size);
-    var price = num(change.price);
+    var size = parseFloat(change.new_size);
+    var price = parseFloat(change.price);
     var order = self.get(change.order_id)
     var tree = self._getTree(change.side);
     var node = tree.find({price: price});

--- a/lib/orderbook_sync.js
+++ b/lib/orderbook_sync.js
@@ -65,6 +65,8 @@ _.assign(OrderbookSync.prototype, new function() {
       _.forEach(self._queue, self.processMessage.bind(self));
       self._queue = [];
 
+      self.emit('bookupdate');
+
     });
   };
 
@@ -94,18 +96,22 @@ _.assign(OrderbookSync.prototype, new function() {
     switch (data.type) {
       case 'open':
         self.book.add(data);
+        self.emit('bookupdate');
         break;
 
       case 'done':
         self.book.remove(data.order_id);
+        self.emit('bookupdate');
         break;
 
       case 'match':
         self.book.match(data);
+        self.emit('bookupdate');
         break;
 
       case 'change':
         self.book.change(data);
+        self.emit('bookupdate');
         break;
     }
   };

--- a/lib/orderbook_sync.js
+++ b/lib/orderbook_sync.js
@@ -44,7 +44,7 @@ _.assign(OrderbookSync.prototype, new function() {
     self.book = new Orderbook();
 
     if (!self.publicClient) {
-      self.publicClient = new PublicClient();
+      self.publicClient = new PublicClient(self.productID);
     }
 
     var args = { 'level': bookLevel };


### PR DESCRIPTION
Without this fix, even if using `new OrderBookSync('BTC-GBP')`, the order book is initialized with BTC-USD from the public client.
The subsequent order updates (coming from BTC-GBP) are then applied on a BTC-USD book. 
This change only changes the product the order book is initialized with.
