### PR TITLE
Fix orderbook_sync init when using productId != BTC-USD

### DIFF
--- a/lib/orderbook_sync.js
+++ b/lib/orderbook_sync.js
@@ -44,7 +44,7 @@ _.assign(OrderbookSync.prototype, new function() {
     self.book = new Orderbook();
 
     if (!self.publicClient) {
-      self.publicClient = new PublicClient();
+      self.publicClient = new PublicClient(self.productID);
     }
 
     var args = { 'level': bookLevel };


### PR DESCRIPTION
Without this fix, even if using `new OrderBookSync('BTC-GBP')`, the order book is initialized with BTC-USD from the public client.
The subsequent order updates (coming from BTC-GBP) are then applied on a BTC-USD book. 
This change only changes the product the order book is initialized with.
