### PR TITLE
(fix) use typeof instead of instanceof to check if args is a function

### DIFF
--- a/lib/clients/authenticated.js
+++ b/lib/clients/authenticated.js
@@ -30,7 +30,7 @@ _.assign(AuthenticatedClient.prototype, new function() {
     var self = this;
 
     opts = opts || {};
-    if (!callback && (opts instanceof Function)) {
+    if (!callback && (typeof opts === 'function')) {
       callback = opts;
       opts = {};
     }
@@ -92,7 +92,7 @@ _.assign(AuthenticatedClient.prototype, new function() {
     var self = this;
 
     args = args || {}
-    if (!callback && (args instanceof Function)) {
+    if (!callback && (typeof args === 'function')) {
       callback = args;
       args = {};
     }
@@ -105,7 +105,7 @@ _.assign(AuthenticatedClient.prototype, new function() {
     var self = this;
 
     args = args || {}
-    if (!callback && (args instanceof Function)) {
+    if (!callback && (typeof args === 'function')) {
       callback = args;
       args = {};
     }
@@ -146,7 +146,7 @@ _.assign(AuthenticatedClient.prototype, new function() {
     var self = this;
 
     args = args || {}
-    if (!callback && (args instanceof Function)) {
+    if (!callback && (typeof args === 'function')) {
       callback = args;
       args = {};
     }
@@ -164,7 +164,7 @@ _.assign(AuthenticatedClient.prototype, new function() {
     var self = this;
 
     args = args || {}
-    if (!callback && (args instanceof Function)) {
+    if (!callback && (typeof args === 'function')) {
       callback = args;
       args = {};
     }

--- a/lib/clients/public.js
+++ b/lib/clients/public.js
@@ -46,7 +46,7 @@ _.assign(PublicClient.prototype, new function() {
   prototype.request = function(method, uriParts, opts, callback) {
     var self = this;
     opts = opts || {};
-    if (!callback && (opts instanceof Function)) {
+    if (!callback && (typeof args === 'function')) {
       callback = opts;
       opts = {};
     }
@@ -74,7 +74,7 @@ _.assign(PublicClient.prototype, new function() {
     var self = this;
 
     args = args || {}
-    if (!callback && (args instanceof Function)) {
+    if (!callback && (typeof args === 'function')) {
       callback = args;
       args = {};
     }
@@ -99,7 +99,7 @@ _.assign(PublicClient.prototype, new function() {
     var self = this;
 
     args = args || {}
-    if (!callback && (args instanceof Function)) {
+    if (!callback && (typeof args === 'function')) {
       callback = args;
       args = {};
     }


### PR DESCRIPTION
Small fix/workaround for using coinbase-exchange in node-webkit
