### PR TITLE
orderbook sync also needs websocket param

### DIFF
--- a/lib/orderbook_sync.js
+++ b/lib/orderbook_sync.js
@@ -8,16 +8,17 @@ var _ = {
 };
 
 // Orderbook syncing
-var OrderbookSync = function(productID, apiURI) {
+var OrderbookSync = function(productID, apiURI, websocketURI) {
   var self = this;
 
   self.productID = productID || 'BTC-USD';
   self.apiURI = apiURI || 'https://api.exchange.coinbase.com';
+  self.websocketURI = websocketURI || 'wss://ws-feed.exchange.coinbase.com';
 
   self._queue = [];
   self._sequence = -1;
 
-  WebsocketClient.call(self, self.productID);
+  WebsocketClient.call(self, self.productID, self.websocketURI);
   self.loadOrderbook();
 };
 


### PR DESCRIPTION
unfortunately that last PR didn't entirely do the trick, we also need a web socket param to sync with the sandbox

@maksim-s 
