### PR TITLE
set socket to null on close

### DIFF
--- a/lib/clients/websocket.js
+++ b/lib/clients/websocket.js
@@ -38,7 +38,6 @@ _.assign(WebsocketClient.prototype, new function() {
     }
 
     self.socket.close();
-    self.onClose();
   };
 
   prototype.onOpen = function() {
@@ -60,6 +59,7 @@ _.assign(WebsocketClient.prototype, new function() {
   prototype.onClose = function() {
     var self = this;
     clearInterval(self.pinger);
+    self.socket = null;
     self.emit('close');
   };
 


### PR DESCRIPTION
you cant close the socket and connect it again because the `self.socket` object is still assigned
